### PR TITLE
Migrate to @dojo scoped package(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# dojo-streams
+# @dojo/streams
 
 [![Build Status](https://travis-ci.org/dojo/streams.svg?branch=master)](https://travis-ci.org/dojo/streams)
 [![codecov](https://codecov.io/gh/dojo/streams/branch/master/graph/badge.svg)](https://codecov.io/gh/dojo/streams)
-[![npm version](https://badge.fury.io/js/dojo-streams.svg)](http://badge.fury.io/js/dojo-streams)
+[![npm version](https://badge.fury.io/js/@dojo/streams.svg)](http://badge.fury.io/js/@dojo/streams)
 
 An implementation of the [WHATWG Streams Spec](https://streams.spec.whatwg.org/).
 

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@types/glob": "~5.0.0",
     "@types/grunt": "~0.4.0",
     "@dojo/interfaces": "2.0.0-alpha.11",
-    "@dojo/loader": "2.0.0-beta.8",
+    "@dojo/loader": "2.0.0-beta.9",
     "grunt": "^1.0.1",
     "grunt-dojo2": ">=2.0.0-beta.19",
     "intern": "^3.3.1",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "dojo-streams",
+  "name": "@dojo/streams",
   "version": "2.0.0-pre",
   "description": "An implementation of the streams standard.",
   "private": true,
@@ -18,17 +18,17 @@
     "test": "grunt test"
   },
   "peerDependencies": {
-    "dojo-core": "^2.0.0-alpha.16",
-    "dojo-has": ">=2.0.0-alpha.6",
-    "dojo-shim": ">=2.0.0-alpha.4"
+    "@dojo/core": "2.0.0-alpha.19",
+    "@dojo/has": "2.0.0-alpha.7",
+    "@dojo/shim": "2.0.0-beta.8"
   },
   "devDependencies": {
     "@types/chai": "~3.4.0",
     "@types/formidable": "~1.0.0",
     "@types/glob": "~5.0.0",
     "@types/grunt": "~0.4.0",
-    "dojo-interfaces": ">=2.0.0-alpha.2",
-    "dojo-loader": ">=2.0.0-beta.7",
+    "@dojo/interfaces": "2.0.0-alpha.11",
+    "@dojo/loader": "2.0.0-beta.8",
     "grunt": "^1.0.1",
     "grunt-dojo2": ">=2.0.0-beta.19",
     "intern": "^3.3.1",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "test": "grunt test"
   },
   "peerDependencies": {
-    "@dojo/core": "2.0.0-alpha.19",
+    "@dojo/core": "2.0.0-alpha.20",
     "@dojo/has": "2.0.0-alpha.7",
     "@dojo/shim": "2.0.0-beta.8"
   },

--- a/src/ArraySink.ts
+++ b/src/ArraySink.ts
@@ -1,4 +1,4 @@
-import Promise from 'dojo-shim/Promise';
+import Promise from '@dojo/shim/Promise';
 import { Sink } from './WritableStream';
 
 // Since this Sink is doing no asynchronous operations,

--- a/src/ArraySource.ts
+++ b/src/ArraySource.ts
@@ -1,4 +1,4 @@
-import Promise from 'dojo-shim/Promise';
+import Promise from '@dojo/shim/Promise';
 import { Source } from './ReadableStream';
 import ReadableStreamController from './ReadableStreamController';
 

--- a/src/ReadableStream.ts
+++ b/src/ReadableStream.ts
@@ -1,4 +1,4 @@
-import Promise from 'dojo-shim/Promise';
+import Promise from '@dojo/shim/Promise';
 import { Strategy } from './interfaces';
 import ReadableStreamController from './ReadableStreamController';
 import ReadableStreamReader from './ReadableStreamReader';

--- a/src/ReadableStreamReader.ts
+++ b/src/ReadableStreamReader.ts
@@ -1,4 +1,4 @@
-import Promise from 'dojo-shim/Promise';
+import Promise from '@dojo/shim/Promise';
 import ReadableStream, { State } from './ReadableStream';
 
 interface ReadRequest<T> {

--- a/src/SeekableStream.ts
+++ b/src/SeekableStream.ts
@@ -1,4 +1,4 @@
-import Promise from 'dojo-shim/Promise';
+import Promise from '@dojo/shim/Promise';
 import { Strategy } from './interfaces';
 import ReadableStream, { Source } from './ReadableStream';
 import { ReadResult } from './ReadableStreamReader';

--- a/src/SeekableStreamReader.ts
+++ b/src/SeekableStreamReader.ts
@@ -1,4 +1,4 @@
-import Promise from 'dojo-shim/Promise';
+import Promise from '@dojo/shim/Promise';
 import ReadableStreamReader, { ReadResult } from './ReadableStreamReader';
 import SeekableStream from './SeekableStream';
 

--- a/src/TransformStream.ts
+++ b/src/TransformStream.ts
@@ -1,7 +1,7 @@
 // This is a simple adaptation to TypeScript of the reference implementation (as of May 2015):
 // https://github.com/whatwg/streams/blob/master/reference-implementation/lib/transform-stream.js
 
-import Promise from 'dojo-shim/Promise';
+import Promise from '@dojo/shim/Promise';
 import { Strategy } from './interfaces';
 import ReadableStream, { Source } from './ReadableStream';
 import ReadableStreamController from './ReadableStreamController';

--- a/src/WritableStream.ts
+++ b/src/WritableStream.ts
@@ -1,4 +1,4 @@
-import Promise from 'dojo-shim/Promise';
+import Promise from '@dojo/shim/Promise';
 import { Strategy } from './interfaces';
 import SizeQueue from './SizeQueue';
 import * as util from './util';

--- a/src/adapters/EventedStreamSource.ts
+++ b/src/adapters/EventedStreamSource.ts
@@ -1,7 +1,7 @@
-import Promise from 'dojo-shim/Promise';
-import Evented from 'dojo-core/Evented';
-import { Handle } from 'dojo-interfaces/core';
-import on, { EventEmitter } from 'dojo-core/on';
+import Promise from '@dojo/shim/Promise';
+import Evented from '@dojo/core/Evented';
+import { Handle } from '@dojo/interfaces/core';
+import on, { EventEmitter } from '@dojo/core/on';
 import { Source } from '../ReadableStream';
 import ReadableStreamController from '../ReadableStreamController';
 

--- a/src/adapters/ReadableNodeStreamSource.ts
+++ b/src/adapters/ReadableNodeStreamSource.ts
@@ -1,4 +1,4 @@
-import Promise from 'dojo-shim/Promise';
+import Promise from '@dojo/shim/Promise';
 import { Source } from '../ReadableStream';
 import ReadableStreamController from '../ReadableStreamController';
 import { Readable } from 'stream';

--- a/src/adapters/WritableNodeStreamSink.ts
+++ b/src/adapters/WritableNodeStreamSink.ts
@@ -1,4 +1,4 @@
-import Promise from 'dojo-shim/Promise';
+import Promise from '@dojo/shim/Promise';
 import { Sink } from '../WritableStream';
 
 export type NodeSourceType = Buffer | string;

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,4 +1,4 @@
-import Promise from 'dojo-shim/Promise';
+import Promise from '@dojo/shim/Promise';
 import { Strategy } from './interfaces';
 
 /*

--- a/tests/intern.ts
+++ b/tests/intern.ts
@@ -12,7 +12,7 @@ export const proxyUrl = 'http://localhost:9000/';
 export const capabilities = {
 	'browserstack.debug': false,
 	project: 'Dojo 2',
-	name: 'dojo-<< package-name >>'
+	name: '@dojo/<< package-name >>'
 };
 
 // Browsers to run integration testing against. Note that version numbers must be strings if used with Sauce
@@ -42,8 +42,8 @@ export const initialBaseUrl: string | null = (function () {
 // The desired AMD loader to use when running unit tests (client.html/client.js). Omit to use the default Dojo
 // loader
 export const loaders = {
-	'host-browser': 'node_modules/dojo-loader/loader.js',
-	'host-node': 'dojo-loader'
+	'host-browser': 'node_modules/@dojo/loader/loader.js',
+	'host-node': '@dojo/loader'
 };
 
 // Configuration options for the module loader; any AMD configuration options supported by the specified AMD loader

--- a/tests/unit/ByteLengthQueuingStrategy.ts
+++ b/tests/unit/ByteLengthQueuingStrategy.ts
@@ -1,6 +1,6 @@
 import * as assert from 'intern/chai!assert';
 import * as registerSuite from 'intern!object';
-import has from 'dojo-has/has';
+import has from '@dojo/has/has';
 import ByteLengthQueuingStrategy from '../../src/ByteLengthQueuingStrategy';
 import WritableStream, { State } from '../../src/WritableStream';
 import ManualSink from './helpers/ManualSink';

--- a/tests/unit/ReadableStream.ts
+++ b/tests/unit/ReadableStream.ts
@@ -7,7 +7,7 @@ import OriginalReadableStream, { State } from '../../src/ReadableStream';
 import ReadableStreamController from '../../src/ReadableStreamController';
 import { ReadResult } from '../../src/ReadableStreamReader';
 import { Strategy } from '../../src/interfaces';
-import Promise from 'dojo-shim/Promise';
+import Promise from '@dojo/shim/Promise';
 import TransformStream, { Transform } from '../../src/TransformStream';
 import WritableStream, { State as WritableState } from '../../src/WritableStream';
 

--- a/tests/unit/ReadableStreamReader.ts
+++ b/tests/unit/ReadableStreamReader.ts
@@ -1,4 +1,4 @@
-import Promise from 'dojo-shim/Promise';
+import Promise from '@dojo/shim/Promise';
 import ReadableStream, { State } from '../../src/ReadableStream';
 
 interface ReadRequest<T> {

--- a/tests/unit/SeekableStream.ts
+++ b/tests/unit/SeekableStream.ts
@@ -3,7 +3,7 @@ import * as registerSuite from 'intern!object';
 
 import ArraySource from '../../src/ArraySource';
 import CountQueuingStrategy from '../../src/CountQueuingStrategy';
-import Promise from 'dojo-shim/Promise';
+import Promise from '@dojo/shim/Promise';
 import { State } from '../../src/ReadableStream';
 import { ReadResult } from '../../src/ReadableStreamReader';
 import SeekableStream from '../../src/SeekableStream';

--- a/tests/unit/TransformStream.ts
+++ b/tests/unit/TransformStream.ts
@@ -1,7 +1,7 @@
 import * as registerSuite from 'intern!object';
 import * as assert from 'intern/chai!assert';
 
-import Promise from 'dojo-shim/Promise';
+import Promise from '@dojo/shim/Promise';
 import { Strategy } from '../../src/interfaces';
 import { State as ReadableState } from '../../src/ReadableStream';
 import ReadableStreamReader, { ReadResult } from '../../src/ReadableStreamReader';

--- a/tests/unit/WritableStream.ts
+++ b/tests/unit/WritableStream.ts
@@ -4,7 +4,7 @@ import WritableStream, { State, Sink } from '../../src/WritableStream';
 import BaseStringSink from './helpers/BaseStringSink';
 import ManualSink from './helpers/ManualSink';
 import { Strategy } from '../../src/interfaces';
-import Promise from 'dojo-shim/Promise';
+import Promise from '@dojo/shim/Promise';
 
 const ASYNC_TIMEOUT = 1000;
 let stream: WritableStream<string>;

--- a/tests/unit/adapters/EventedStreamSource.ts
+++ b/tests/unit/adapters/EventedStreamSource.ts
@@ -1,7 +1,7 @@
 import * as registerSuite from 'intern!object';
 import * as assert from 'intern/chai!assert';
 
-import Evented from 'dojo-core/Evented';
+import Evented from '@dojo/core/Evented';
 import ReadableStream from '../../../src/ReadableStream';
 import ReadableStreamReader, { ReadResult } from '../../../src/ReadableStreamReader';
 import EventedStreamSource from '../../../src/adapters/EventedStreamSource';

--- a/tests/unit/adapters/ReadableNodeStreamSource.ts
+++ b/tests/unit/adapters/ReadableNodeStreamSource.ts
@@ -1,7 +1,7 @@
 import * as registerSuite from 'intern!object';
 import * as assert from 'intern/chai!assert';
 import { Readable } from 'stream';
-import Promise from 'dojo-shim/Promise';
+import Promise from '@dojo/shim/Promise';
 import ReadableStream from '../../../src/ReadableStream';
 import { ReadResult } from '../../../src/ReadableStreamReader';
 import ReadableStreamController from '../../../src/ReadableStreamController';

--- a/tests/unit/helpers/BaseStringSink.ts
+++ b/tests/unit/helpers/BaseStringSink.ts
@@ -1,5 +1,5 @@
 import { Sink } from '../../../src/WritableStream';
-import Promise from 'dojo-shim/Promise';
+import Promise from '@dojo/shim/Promise';
 
 export default class BaseStringSink implements Sink<string> {
 

--- a/tests/unit/helpers/BaseStringSource.ts
+++ b/tests/unit/helpers/BaseStringSource.ts
@@ -1,6 +1,6 @@
 import ReadableStreamController from '../../../src/ReadableStreamController';
 import { Source } from '../../../src/ReadableStream';
-import Promise from 'dojo-shim/Promise';
+import Promise from '@dojo/shim/Promise';
 
 export default class BaseStringSource implements Source<string> {
 

--- a/tests/unit/helpers/ManualSink.ts
+++ b/tests/unit/helpers/ManualSink.ts
@@ -1,5 +1,5 @@
 import { Sink } from '../../../src/WritableStream';
-import Promise from 'dojo-shim/Promise';
+import Promise from '@dojo/shim/Promise';
 
 // A sink whose write operations must be manually resolved by calling 'next'
 export default class ManualSink<T> implements Sink<T> {

--- a/typings.json
+++ b/typings.json
@@ -1,11 +1,9 @@
 {
 	"name": "dojo-streams",
-	"globalDevDependencies": {
-		"digdug": "github:dojo/typings/custom/digdug/digdug.d.ts#a62873258aa1deed48f9882c193c335436100d4b",
-		"dojo2": "github:dojo/typings/custom/dojo2/dojo.d.ts#a62873258aa1deed48f9882c193c335436100d4b",
-		"dojo2-dev": "github:dojo/typings/custom/dev/dev.d.ts#288d3a9868194f0e1ad6687371dffd1d96cb39a1",
-		"intern": "github:dojo/typings/custom/intern/intern.d.ts#122b1902bdbdb7b94bdee35bbc27bc6747e1979d",
-		"leadfoot": "github:dojo/typings/custom/leadfoot/leadfoot.d.ts#840dfb52b52ec130e0ab2625663c68387adf1377",
+	"globalDependencies": {
 		"symbol-shim": "github:dojo/typings/custom/symbol-shim/symbol-shim.d.ts#9a0185f465a3febe2bb1ff3f1210f43e5f96c5d2"
+	},
+	"globalDevDependencies": {
+		"dojo2-dev": "github:dojo/typings/custom/dev/dev.d.ts#288d3a9868194f0e1ad6687371dffd1d96cb39a1"
 	}
 }


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue

**Description:**

Update `package.json` and all dependency references to use `@dojo` namespace.

Related to https://github.com/dojo/meta/issues/129