### PR TITLE
Update Dojo URL in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "2.0.0-pre",
   "description": "An implementation of the streams standard.",
   "private": true,
-  "homepage": "http://dojotoolkit.org",
+  "homepage": "https://dojo.io",
   "bugs": {
     "url": "https://github.com/dojo/streams/issues"
   },


### PR DESCRIPTION
Updated the homepage URL in package.json to point to https://dojo.io.

Refs: dojo/meta#166